### PR TITLE
Add ingress_threads parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ Minimum requirements:
 
 Approximate run time: ~40min for 1 million reads in total (24 barcodes) using Kraken2 and the Standard-8 database (using a previously downloaded db).
 
+### High performance compute nodes
+
+For systems with large numbers of CPU cores and ample memory (for example a node
+with 128 threads and 256 GB RAM), increase `--threads` and `--ingress_threads`
+to utilise the available resources. When working with Kraken2 databases larger
+than the available memory, enable `--kraken2_memory_mapping` to reduce RAM
+usage.
+
 ARM processor support: True
 
 
@@ -239,6 +247,7 @@ input_reads.fastq   ─── input_directory  ─── input_directory
 | min_read_qual | number | Specify read quality lower limit. | Any reads with a quality lower than this limit will not be included in the analysis. |  |
 | max_len | integer | Specify read length upper limit | Any reads longer than this limit will not be included in the analysis. |  |
 | threads | integer | Maximum number of CPU threads to use in each parallel workflow task. | Several tasks in this workflow benefit from using multiple CPU threads. This option sets the number of CPU threads for all such processes. See server threads parameter for Kraken specific threads in the real_time pipeline. | 4 |
+| ingress_threads | integer | CPU threads for ingestion steps. | Adjusts the number of CPU threads used by fastcat and BAM processing tasks. | 4 |
 
 
 

--- a/docs/03_compute_requirements.md
+++ b/docs/03_compute_requirements.md
@@ -11,3 +11,10 @@ Minimum requirements:
 Approximate run time: ~40min for 1 million reads in total (24 barcodes) using Kraken2 and the Standard-8 database (using a previously downloaded db).
 
 ARM processor support: True
+
+### High performance compute nodes
+
+When running on large-memory machines (e.g. 256 GB RAM with 128 CPU threads),
+increase the `--threads` and `--ingress_threads` parameters to make use of the
+available cores. For Kraken2 databases larger than the available memory, enable
+`--kraken2_memory_mapping` to avoid loading the entire database into RAM.

--- a/docs/06_input_parameters.md
+++ b/docs/06_input_parameters.md
@@ -101,5 +101,6 @@
 | min_read_qual | number | Specify read quality lower limit. | Any reads with a quality lower than this limit will not be included in the analysis. |  |
 | max_len | integer | Specify read length upper limit | Any reads longer than this limit will not be included in the analysis. |  |
 | threads | integer | Maximum number of CPU threads to use in each parallel workflow task. | Several tasks in this workflow benefit from using multiple CPU threads. This option sets the number of CPU threads for all such processes. See server threads parameter for Kraken specific threads in the real_time pipeline. | 4 |
+| ingress_threads | integer | CPU threads for ingestion steps. | Adjusts the number of CPU threads used by fastcat and BAM processing tasks. | 4 |
 
 

--- a/lib/ingress.nf
+++ b/lib/ingress.nf
@@ -567,7 +567,7 @@ def xam_ingress(Map arguments)
 process fastcat {
     label "ingress"
     label "wf_common"
-    cpus 4
+    cpus params.ingress_threads
     memory "2 GB"
     input:
         tuple val(meta), path(input_src, stageAs: "input_src")
@@ -678,7 +678,7 @@ process validateIndex {
 process mergeBams {
     label "ingress"
     label "wf_common"
-    cpus 3
+    cpus params.ingress_threads
     memory "4 GB"
     input: tuple val(meta), path("input_bams/reads*.bam")
     output: tuple val(meta), path("reads.bam"), path("reads.bam.bai")
@@ -695,7 +695,7 @@ process mergeBams {
 process catSortBams {
     label "ingress"
     label "wf_common"
-    cpus 4
+    cpus params.ingress_threads
     memory "4 GB"
     input: tuple val(meta), path("input_bams/reads*.bam")
     output: tuple val(meta), path("reads.bam"), path("reads.bam.bai")
@@ -711,7 +711,7 @@ process catSortBams {
 process sortBam {
     label "ingress"
     label "wf_common"
-    cpus 3
+    cpus params.ingress_threads
     memory "4 GB"
     input: tuple val(meta), path("reads.bam")
     output: tuple val(meta), path("reads.sorted.bam"), path("reads.sorted.bam.bai")
@@ -726,7 +726,7 @@ process sortBam {
 process bamstats {
     label "ingress"
     label "wf_common"
-    cpus 3
+    cpus params.ingress_threads
     memory "4 GB"
     input:
         tuple val(meta), path("reads.bam"), path("reads.bam.bai")
@@ -1307,7 +1307,7 @@ process validate_sample_sheet {
 
 // Generate an index for an input XAM file
 process samtools_index {
-    cpus 4
+    cpus params.ingress_threads
     label "ingress"
     label "wf_common"
     memory 4.GB

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,6 +24,7 @@ params {
     min_len = 0
     min_read_qual = null
     threads = 4
+    ingress_threads = 4
     server_threads = 2
     kraken_clients = 2
     // Databases

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -472,6 +472,13 @@
                     "title": "Number of CPU threads per workflow task",
                     "description": "Maximum number of CPU threads to use in each parallel workflow task.",
                     "help_text": "Several tasks in this workflow benefit from using multiple CPU threads. This option sets the number of CPU threads for all such processes. See server threads parameter for Kraken specific threads in the real_time pipeline."
+                },
+                "ingress_threads": {
+                    "type": "integer",
+                    "default": 4,
+                    "title": "CPU threads for ingestion steps",
+                    "description": "Number of CPU threads used by ingestion processes such as fastcat and BAM manipulation.",
+                    "help_text": "Increase this on large machines to accelerate file ingestion (fastcat, mergeBams, sortBam and bamstats)."
                 }
             }
         },


### PR DESCRIPTION
## Summary
- introduce `ingress_threads` option for ingest processes
- use new parameter in ingestion steps
- document new option in README and docs
- add HPC tuning advice

## Testing
- `pip install bokeh pandas numpy ezcharts dominate`
- `pytest bin/workflow_glue/tests -q --test_data test_data`

------
https://chatgpt.com/codex/tasks/task_b_68546093892c8320aa5804ab97e208da